### PR TITLE
fix(commands/Transfer): do not allow transferring to self

### DIFF
--- a/commands/Points/Transfer.ts
+++ b/commands/Points/Transfer.ts
@@ -25,7 +25,7 @@ export default class Transfer extends Command {
 			throw new CommandError('LOCKED_POINTS');
 		}
 		const user = await Util.users(message, 1);
-		if (!user) {
+		if (!user || user.id === message.author.id) {
 			throw new CommandError('MENTION_USER');
 		}
 		if (this.client.lockedPoints.has(user.id)) {


### PR DESCRIPTION
**What changes does this PR offer, and why should it be merged?**:
This PR fixes an issue with the transfer command in which a user could duplicate points by transferring to themselves

- [x] This PR fixes or resolves an issue or issues: 
  - [x] This PR is a bugfix

**Additional Information**:
